### PR TITLE
re-organise work files, add periods at live cart

### DIFF
--- a/src/app/banner-display/[district]/page.tsx
+++ b/src/app/banner-display/[district]/page.tsx
@@ -224,7 +224,20 @@ export default function BannerDisplayPage() {
         console.log('🔍 Fetched data:', data);
 
         if (data && data.length > 0) {
-          const transformed = data.map(
+          // 구별 가나다순 정렬
+          const sortedData = [...data].sort((a, b) => {
+            const districtCompare = a.region_gu.name.localeCompare(
+              b.region_gu.name
+            );
+            if (districtCompare !== 0) return districtCompare;
+
+            // 같은 구 내에서는 panel_code로 정렬
+            const aCode = a.panel_code || 0;
+            const bCode = b.panel_code || 0;
+            return aCode - bCode;
+          });
+
+          const transformed = sortedData.map(
             (item: BannerDisplayData, index: number) => {
               const displayName =
                 item.address && item.address.trim() !== ''
@@ -251,8 +264,15 @@ export default function BannerDisplayPage() {
                   ? item.banner_slot_info[0].second_half_closure_quantity
                   : undefined;
 
+              // 구별 가나다순 ID 조합 (중복 방지)
+              const districtCode = item.region_gu.code;
+              const panelCode = item.panel_code || index + 1;
+              const combinedId = `${districtCode}-${panelCode
+                .toString()
+                .padStart(2, '0')}-${item.id}`; // UUID 추가로 고유성 보장
+
               return {
-                id: index + 1, // 단순한 인덱스 사용
+                id: combinedId, // "gwanak-01-uuid123", "mapo-01-uuid456" 등
                 type: 'banner',
                 district: item.region_gu.name,
                 name: displayName,
@@ -292,7 +312,7 @@ export default function BannerDisplayPage() {
             .filter((b) => b.location.split(' ')[0] === district)
             .map(
               (item): BannerBillboard => ({
-                id: Number(item.id),
+                id: `${district}-${item.id.toString().padStart(2, '0')}`, // string으로 변경
                 type: 'banner', // 타입을 'banner'로 설정
                 district: item.location.split(' ')[0],
                 name: item.title,

--- a/src/app/banner-display/page.tsx
+++ b/src/app/banner-display/page.tsx
@@ -196,6 +196,9 @@ export default function BannerDisplayPage() {
           Boolean
         ) as District[];
 
+        // 구별 가나다순 정렬
+        districtData.sort((a, b) => a.name.localeCompare(b.name));
+
         // "전체" 카드 추가 (모든 구의 합계)
         const totalCount = Object.values(counts).reduce(
           (sum, count) => sum + count,

--- a/src/app/banner-display/page.tsx
+++ b/src/app/banner-display/page.tsx
@@ -23,6 +23,7 @@ interface District {
   logo: string;
   src: string;
   code: string;
+  is_for_admin?: boolean; // 행정용 구분
   period?: {
     first_half_from: string;
     first_half_to: string;
@@ -121,35 +122,15 @@ export default function BannerDisplayPage() {
                   code: 'gangdong',
                   description: '울림픽대교 남단사거리 앞 외 3건',
                 },
-                관악구: {
-                  id: 3,
-                  code: 'gwanak',
-                  description: '서울대입구역 앞 외 3건',
-                },
-                마포구: {
-                  id: 4,
-                  code: 'mapo',
-                  description: '홍대입구역 앞 외 5건',
-                },
-                서대문구: {
-                  id: 5,
-                  code: 'seodaemun',
-                  description: '울림픽대교 남단사거리 앞 외 3건',
-                },
-                송파구: {
-                  id: 6,
-                  code: 'songpa',
-                  description: '잠실종합운동장 앞 외 5건',
-                },
-                용산구: {
-                  id: 7,
-                  code: 'yongsan',
-                  description: '여의도공원 앞 외 6건',
-                },
                 강북구: {
                   id: 8,
                   code: 'gangbuk',
                   description: '여의도공원 앞 외 6건',
+                },
+                관악구: {
+                  id: 3,
+                  code: 'gwanak',
+                  description: '서울대입구역 앞 외 3건',
                 },
                 광진구: {
                   id: 10,
@@ -165,6 +146,27 @@ export default function BannerDisplayPage() {
                   id: 12,
                   code: 'dongdaemun',
                   description: '울림픽대교 남단사거리 앞 외 3건',
+                },
+                마포구: {
+                  id: 4,
+                  code: 'mapo',
+                  description: '홍대입구역 앞 외 5건',
+                },
+                서대문구: {
+                  id: 5,
+                  code: 'seodaemun',
+                  description: '울림픽대교 남단사거리 앞 외 3건',
+                  is_for_admin: true, // 행정용 구분
+                },
+                송파구: {
+                  id: 6,
+                  code: 'songpa',
+                  description: '잠실종합운동장 앞 외 5건',
+                },
+                용산구: {
+                  id: 7,
+                  code: 'yongsan',
+                  description: '여의도공원 앞 외 6건',
                 },
               }[districtName];
 
@@ -182,6 +184,7 @@ export default function BannerDisplayPage() {
                   logosMap[districtName] ||
                   `/images/district-icon/${baseInfo.code}-gu.png`,
                 src: '/images/led/landing.png',
+                is_for_admin: baseInfo.is_for_admin || false,
                 period,
                 bankInfo,
               };

--- a/src/app/cart/page.tsx
+++ b/src/app/cart/page.tsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import Link from 'next/link';
 import { useCart } from '@/src/contexts/cartContext';
 import { useState, useEffect } from 'react';
-import CartItemAccordion from './cart/cartItemAccordion';
+import CartItemAccordion from '@/src/components/cartItemAccordion';
 
 const fadeInUp = {
   initial: { y: 60, opacity: 0 },

--- a/src/components/cartItemAccordion.tsx
+++ b/src/components/cartItemAccordion.tsx
@@ -17,6 +17,33 @@ export default function CartItemAccordion({ item }: CartItemAccordionProps) {
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const getPanelTypeLabel = (panelType?: string) => {
+    if (!panelType) return '현수막게시대';
+
+    switch (panelType) {
+      case 'multi-panel':
+        return '연립형';
+      case 'lower-panel':
+        return '저단형';
+      case 'bulletin-board':
+        return '시민게시대';
+      case 'citizen-board':
+        return '시민/문화게시대';
+      case 'with_lighting':
+        return '조명형';
+      case 'no_lighting':
+        return '비조명형';
+      case 'semi-auto':
+        return '반자동';
+      case 'panel':
+        return '패널형';
+      case 'led':
+        return 'LED전자게시대';
+      default:
+        return '현수막게시대';
+    }
+  };
+
   const handleFileInputClick = () => {
     if (!sendByEmail) fileInputRef.current?.click();
   };
@@ -41,6 +68,11 @@ export default function CartItemAccordion({ item }: CartItemAccordionProps) {
         {item.halfPeriod && (
           <span className="ml-2 text-sm text-blue-600 font-medium">
             ({item.halfPeriod === 'first_half' ? '상반기' : '하반기'})
+          </span>
+        )}
+        {item.panel_type && (
+          <span className="ml-2 text-sm text-gray-400 font-medium">
+            ({getPanelTypeLabel(item.panel_type)})
           </span>
         )}
       </div>

--- a/src/components/displayDetailPage.tsx
+++ b/src/components/displayDetailPage.tsx
@@ -71,7 +71,7 @@ export default function DisplayDetailPage({
   const [viewType, setViewType] = useState<'location' | 'gallery' | 'list'>(
     defaultView
   );
-  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [mapoFilter, setMapoFilter] = useState<'yeollip' | 'jeodan' | 'simin'>(
     'yeollip'
   );
@@ -159,7 +159,7 @@ export default function DisplayDetailPage({
     }
   };
 
-  const handleItemSelect = (id: number, checked?: boolean) => {
+  const handleItemSelect = (id: string, checked?: boolean) => {
     const alreadySelected = selectedIds.includes(id);
     let newSelectedIds;
 
@@ -464,7 +464,7 @@ export default function DisplayDetailPage({
               showHeader
               showCheckbox
               selectedIds={selectedIds}
-              onItemSelect={(id) => handleItemSelect(id)}
+              onItemSelect={(id, checked) => handleItemSelect(id, checked)}
               enableRowClick={false}
             />
           ) : (

--- a/src/components/displayDetailPage.tsx
+++ b/src/components/displayDetailPage.tsx
@@ -136,6 +136,14 @@ export default function DisplayDetailPage({
         return '시민게시대';
       case 'citizen-board':
         return '시민/문화게시대';
+      case 'with_lighting':
+        return '조명형';
+      case 'no_lighting':
+        return '비조명형';
+      case 'semi-auto':
+        return '반자동';
+      case 'panel':
+        return '패널형';
       default:
         return '현수막게시대';
     }
@@ -194,6 +202,7 @@ export default function DisplayDetailPage({
           district: item.district,
           price: priceForCart,
           halfPeriod: selectedHalfPeriod,
+          panel_type: item.panel_type,
         };
 
         console.log('🔍 Adding item to cart:', cartItem);

--- a/src/components/displayDetailPage.tsx
+++ b/src/components/displayDetailPage.tsx
@@ -135,7 +135,7 @@ export default function DisplayDetailPage({
       case 'bulletin-board':
         return '시민게시대';
       case 'citizen-board':
-        return '시민/문화게시판';
+        return '시민/문화게시대';
       default:
         return '현수막게시대';
     }

--- a/src/components/kakaoMap.tsx
+++ b/src/components/kakaoMap.tsx
@@ -5,7 +5,7 @@ import { Map, MapMarker } from 'react-kakao-maps-sdk';
 import useKakaoLoader from './hooks/use-kakao-loader';
 
 export interface MarkerType {
-  id: number;
+  id: string;
   title: string;
   lat: number;
   lng: number;
@@ -15,8 +15,8 @@ export interface MarkerType {
 
 interface KakaoMapProps {
   markers: MarkerType[];
-  selectedIds: number[];
-  onSelect: (id: number) => void;
+  selectedIds: string[];
+  onSelect: (id: string) => void;
 }
 
 const KakaoMap: React.FC<KakaoMapProps> = ({

--- a/src/components/ledDisplayDetailPage.tsx
+++ b/src/components/ledDisplayDetailPage.tsx
@@ -132,6 +132,7 @@ export default function LEDDisplayDetailPage({
           name: getCartItemName(item),
           district: item.district,
           price: priceForCart,
+          panel_type: item.panel_type,
         };
 
         console.log('🔍 Adding LED item to cart:', cartItem);

--- a/src/components/ledDisplayDetailPage.tsx
+++ b/src/components/ledDisplayDetailPage.tsx
@@ -147,6 +147,20 @@ export default function LEDDisplayDetailPage({
     setSelectedIds(newSelectedIds);
   };
 
+  const handleRowClick = (e: React.MouseEvent, itemId: string) => {
+    if ((e.target as HTMLElement).tagName === 'INPUT') {
+      return;
+    }
+
+    // 아이콘 버튼 영역 클릭 시 아이템 선택 방지
+    const target = e.target as HTMLElement;
+    if (target.closest('button') || target.tagName === 'BUTTON') {
+      return;
+    }
+
+    handleItemSelect(itemId, true);
+  };
+
   const renderGalleryView = () => (
     <div className="grid grid-cols-3 sm:grid-cols-1 md:grid-cols-4 lg:grid-cols-4 gap-6 ">
       {filteredBillboards.map((item, index) => {
@@ -156,7 +170,7 @@ export default function LEDDisplayDetailPage({
           <div
             key={uniqueKey}
             className={`flex flex-col cursor-pointer `}
-            onClick={() => handleItemSelect(item.id)}
+            onClick={(e) => handleRowClick(e, item.id)}
           >
             <div
               className={`relative aspect-[1/1] w-full overflow-hidden rounded-lg ${
@@ -213,7 +227,7 @@ export default function LEDDisplayDetailPage({
               <div
                 key={uniqueKey}
                 className={`flex flex-col cursor-pointer `}
-                onClick={() => handleItemSelect(item.id)}
+                onClick={(e) => handleRowClick(e, item.id)}
               >
                 <div
                   className={`relative aspect-[1/1] w-full overflow-hidden rounded-lg ${

--- a/src/components/ledDisplayDetailPage.tsx
+++ b/src/components/ledDisplayDetailPage.tsx
@@ -66,7 +66,7 @@ export default function LEDDisplayDetailPage({
   const [viewType, setViewType] = useState<'location' | 'gallery' | 'list'>(
     defaultView
   );
-  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const { dispatch } = useCart();
   const router = useRouter();
 
@@ -107,7 +107,7 @@ export default function LEDDisplayDetailPage({
     }
   };
 
-  const handleItemSelect = (id: number, checked?: boolean) => {
+  const handleItemSelect = (id: string, checked?: boolean) => {
     const alreadySelected = selectedIds.includes(id);
     let newSelectedIds;
 
@@ -354,7 +354,7 @@ export default function LEDDisplayDetailPage({
               showHeader
               showCheckbox
               selectedIds={selectedIds}
-              onItemSelect={(id) => handleItemSelect(id)}
+              onItemSelect={(id, checked) => handleItemSelect(id, checked)}
               enableRowClick={false}
             />
           ) : (

--- a/src/components/liveCart.tsx
+++ b/src/components/liveCart.tsx
@@ -108,6 +108,13 @@ export default function LiveCart() {
                     <span className="font-bold mr-2">
                       ({getPanelTypeLabel(item.panel_type)})
                     </span>
+                    {item.halfPeriod && (
+                      <span className="ml-2 text-sm text-blue-600 font-medium">
+                        (
+                        {item.halfPeriod === 'first_half' ? '상반기' : '하반기'}
+                        )
+                      </span>
+                    )}
                   </div>
                   <span className="mr-2 text-gray-500">{item.district}</span>
                 </div>

--- a/src/components/liveCart.tsx
+++ b/src/components/liveCart.tsx
@@ -9,6 +9,32 @@ export default function LiveCart() {
   const router = useRouter();
   const [timeLeft, setTimeLeft] = useState<string>('');
 
+  const getPanelTypeLabel = (panelType?: string) => {
+    if (!panelType) return '현수막게시대';
+
+    switch (panelType) {
+      case 'multi-panel':
+        return '연립형';
+      case 'lower-panel':
+        return '저단형';
+      case 'bulletin-board':
+        return '시민게시대';
+      case 'citizen-board':
+        return '시민/문화게시대';
+      case 'with_lighting':
+        return '조명형';
+      case 'no_lighting':
+        return '비조명형';
+      case 'semi-auto':
+        return '반자동';
+      case 'panel':
+        return '패널형';
+      case 'led':
+        return 'LED전자게시대';
+      default:
+        return '현수막게시대';
+    }
+  };
   // 디버깅용: cart 배열 상태 확인
   console.log('🔍 Cart state in LiveCart:', cart);
   console.log('🔍 Cart length in LiveCart:', cart.length);
@@ -80,7 +106,7 @@ export default function LiveCart() {
                   <div>
                     <span className="mr-2">{item.name}</span>
                     <span className="font-bold mr-2">
-                      ({item.type === 'led-display' ? 'LED' : '배너'})
+                      ({getPanelTypeLabel(item.panel_type)})
                     </span>
                   </div>
                   <span className="mr-2 text-gray-500">{item.district}</span>

--- a/src/components/liveCart.tsx
+++ b/src/components/liveCart.tsx
@@ -120,8 +120,10 @@ export default function LiveCart() {
                 </div>
 
                 <div className="flex flex-col items-center gap-2">
-                  <button
-                    className="ml-auto text-red-500"
+                  <Button
+                    variant="default"
+                    size="sm"
+                    className="ml-auto text-red-500 p-0 bg-transparent border-none"
                     onClick={() =>
                       dispatch({ type: 'REMOVE_ITEM', id: item.id })
                     }
@@ -132,7 +134,7 @@ export default function LiveCart() {
                       width={20}
                       height={20}
                     />
-                  </button>{' '}
+                  </Button>
                   <span className="mr-2">
                     {item.price === 0
                       ? '상담문의'

--- a/src/components/ui/itemlist.tsx
+++ b/src/components/ui/itemlist.tsx
@@ -87,7 +87,7 @@ const ItemList: React.FC<ItemTableProps> = ({
       case 'bulletin-board':
         return '시민게시대';
       case 'citizen-board':
-        return '시민/문화게시판';
+        return '시민/문화게시대';
       default:
         return '현수막게시대';
     }

--- a/src/components/ui/itemlist.tsx
+++ b/src/components/ui/itemlist.tsx
@@ -31,8 +31,8 @@ interface ItemTableProps {
   showHeader?: boolean;
   showCheckbox?: boolean;
   renderAction?: (item: DisplayBillboard) => React.ReactNode;
-  onItemSelect?: (id: number, checked: boolean) => void;
-  selectedIds?: number[];
+  onItemSelect?: (id: string, checked: boolean) => void;
+  selectedIds?: string[];
   enableRowClick?: boolean;
 }
 
@@ -54,7 +54,7 @@ const ItemList: React.FC<ItemTableProps> = ({
     page * ITEMS_PER_PAGE
   );
 
-  const handleItemClick = (itemId: number) => {
+  const handleItemClick = (itemId: string) => {
     if (onItemSelect) {
       const isSelected = selectedIds.includes(itemId);
       onItemSelect(itemId, !isSelected);
@@ -72,7 +72,7 @@ const ItemList: React.FC<ItemTableProps> = ({
       return;
     }
 
-    handleItemClick(itemId);
+    handleItemClick(itemId.toString());
   };
 
   // 구분 컬럼에 표시할 값 계산 함수

--- a/src/components/ui/itemlist.tsx
+++ b/src/components/ui/itemlist.tsx
@@ -61,7 +61,7 @@ const ItemList: React.FC<ItemTableProps> = ({
     }
   };
 
-  const handleRowClick = (e: React.MouseEvent, itemId: number) => {
+  const handleRowClick = (e: React.MouseEvent, itemId: string) => {
     if ((e.target as HTMLElement).tagName === 'INPUT') {
       return;
     }
@@ -88,6 +88,14 @@ const ItemList: React.FC<ItemTableProps> = ({
         return '시민게시대';
       case 'citizen-board':
         return '시민/문화게시대';
+      case 'with_lighting':
+        return '조명형';
+      case 'no_lighting':
+        return '비조명형';
+      case 'semi-auto':
+        return '반자동';
+      case 'panel':
+        return '패널형';
       default:
         return '현수막게시대';
     }

--- a/src/components/ui/ledItemList.tsx
+++ b/src/components/ui/ledItemList.tsx
@@ -25,8 +25,8 @@ interface LEDItemTableProps {
   showHeader?: boolean;
   showCheckbox?: boolean;
   renderAction?: (item: LEDBillboard) => React.ReactNode;
-  onItemSelect?: (id: number, checked: boolean) => void;
-  selectedIds?: number[];
+  onItemSelect?: (id: string, checked: boolean) => void;
+  selectedIds?: string[];
   enableRowClick?: boolean;
 }
 
@@ -48,7 +48,7 @@ const LEDItemList: React.FC<LEDItemTableProps> = ({
     page * ITEMS_PER_PAGE
   );
 
-  const handleItemClick = (itemId: number) => {
+  const handleItemClick = (itemId: string) => {
     if (onItemSelect) {
       const isSelected = selectedIds.includes(itemId);
       onItemSelect(itemId, !isSelected);
@@ -66,7 +66,7 @@ const LEDItemList: React.FC<LEDItemTableProps> = ({
       return;
     }
 
-    handleItemClick(itemId);
+    handleItemClick(itemId.toString());
   };
 
   // LED 전용 구분 컬럼에 표시할 값 계산 함수

--- a/src/components/ui/ledItemList.tsx
+++ b/src/components/ui/ledItemList.tsx
@@ -55,7 +55,7 @@ const LEDItemList: React.FC<LEDItemTableProps> = ({
     }
   };
 
-  const handleRowClick = (e: React.MouseEvent, itemId: number) => {
+  const handleRowClick = (e: React.MouseEvent, itemId: string) => {
     if ((e.target as HTMLElement).tagName === 'INPUT') {
       return;
     }

--- a/src/contexts/cartContext.tsx
+++ b/src/contexts/cartContext.tsx
@@ -2,7 +2,7 @@
 import React, { createContext, useContext, useReducer, useEffect } from 'react';
 
 export interface CartItem {
-  id: number;
+  id: string;
   type: 'led-display' | 'banner-display';
   name: string;
   district: string;
@@ -17,7 +17,7 @@ interface CartState {
 
 type CartAction =
   | { type: 'ADD_ITEM'; item: CartItem }
-  | { type: 'REMOVE_ITEM'; id: number }
+  | { type: 'REMOVE_ITEM'; id: string }
   | { type: 'CLEAR_CART' }
   | { type: 'LOAD_CART'; state: CartState };
 

--- a/src/contexts/cartContext.tsx
+++ b/src/contexts/cartContext.tsx
@@ -8,6 +8,7 @@ export interface CartItem {
   district: string;
   price: number;
   halfPeriod?: 'first_half' | 'second_half';
+  panel_type?: string;
 }
 
 interface CartState {

--- a/src/types/displaydetail.ts
+++ b/src/types/displaydetail.ts
@@ -9,7 +9,7 @@ export interface District {
 }
 
 export interface DistrictItem {
-  id: number;
+  id: string;
   title: string;
   subtitle: string;
   image: string;
@@ -21,7 +21,7 @@ export interface DistrictItem {
 
 // 공통 베이스 타입
 export interface BaseBillboard {
-  id: number;
+  id: string;
   district: string;
   name: string;
   neighborhood: string;
@@ -69,7 +69,7 @@ export interface LEDBillboard extends BaseBillboard {
 export type DisplayBillboard = BannerBillboard | LEDBillboard;
 
 export interface ListItem {
-  id: number;
+  id: string;
   title: string;
   subtitle?: string;
   location?: string;

--- a/src/types/leddetail.ts
+++ b/src/types/leddetail.ts
@@ -1,5 +1,5 @@
 export interface LEDBillboard {
-  id: number;
+  id: string;
   type: 'led';
   district: string;
   name: string;


### PR DESCRIPTION
## 어떤 변경인지

- [x] feat: 기능 변경, 기능 추가
- [x] fix: 버그 수정
- [ ] design: css만 수정
- [ ] refactor: 동작 변경 없는 수정
- [ ] style: 내용 변경 없는 수정 (린트, 포맷 변경 등)
- [ ] build: src 외부 코드 수정
- [ ] remove: 파일 삭제
- [ ] docs: 문서 작업 (README, pr 템플릿)
- [ ] setting : 폴더 구조 세팅
- [ ] chore: 기타 작업

## 설명

> pr 내용을 간략히 설명해주세요.
led, banner 페이지 목록으로보기에서 체크박스에 체크시에 무작위의 다른 아이템이 선택되는것을 수정했습니다.
이를 위해 우선 led, banner 테이블의 전체 구를 걸쳐 아이템에 고유아이디를 부여했습니다.
조합은 region_gu.code - panel_info.panel_code - panel_info.id 형식으로 했습니다. 

그리고 라이브 장바구니에 상하반기 기한표기, panel_type 표기를 추가했습니다. 

### 이슈 번호

> 예) https://github.com/hansung-design-dev/hansung-design[이슈번호]
> https://github.com/hansung-design-dev/hansung-design/

### To Reviewers

close #
